### PR TITLE
feat: Add icons to repository listings

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,3 +1,23 @@
+function getRepoIcon(name, description) {
+  constsearchText = (name + ' ' + (description || '')).toLowerCase();
+
+  // Using simple emojis as placeholders for now.
+  // Later, these could be replaced with SVG URLs or classes for an icon font.
+  if (searchText.includes('python')) return '🐍';
+  if (searchText.includes('javascript') || searchText.includes('js')) return '💛'; // Yellow heart for JS
+  if (searchText.includes('html')) return '📄';
+  if (searchText.includes('css')) return '🎨';
+  if (searchText.includes('portfolio')) return '💼';
+  if (searchText.includes('api')) return '🔗';
+  if (searchText.includes('data')) return '📊';
+  if (searchText.includes('flutter')) return '📱';
+  if (searchText.includes('dart')) return '🎯';
+  if (searchText.includes('react')) return '⚛️'; // React atom symbol
+  if (searchText.includes('node')) return '🟩'; // Green square for Node.js
+
+  return '📁'; // Default folder icon
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   const repoContainer = document.querySelector(".repo-container");
 
@@ -8,9 +28,24 @@ document.addEventListener("DOMContentLoaded", () => {
         const repoCard = document.createElement("div");
         repoCard.classList.add("repo-card");
 
+        // Create icon
+        const iconEmoji = getRepoIcon(repo.name, repo.description);
+        const iconElement = document.createElement('span');
+        iconElement.textContent = iconEmoji;
+        iconElement.classList.add('repo-icon');
+
+        // Create name
         const repoName = document.createElement("h3");
         repoName.textContent = repo.name;
+        // No need for inline-block on h3 directly if handled by parent flex
 
+        // Create header div for icon and name
+        const repoHeader = document.createElement('div');
+        repoHeader.classList.add('repo-header');
+        repoHeader.appendChild(iconElement);
+        repoHeader.appendChild(repoName);
+
+        // Create description and link
         const repoDescription = document.createElement("p");
         repoDescription.textContent = repo.description || "No description provided.";
 
@@ -19,9 +54,11 @@ document.addEventListener("DOMContentLoaded", () => {
         repoLink.textContent = "View Repository";
         repoLink.target = "_blank";
 
-        repoCard.appendChild(repoName);
+        // Append elements to repoCard
+        repoCard.appendChild(repoHeader); // Header first
         repoCard.appendChild(repoDescription);
         repoCard.appendChild(repoLink);
+
         repoContainer.appendChild(repoCard);
       });
     })

--- a/styles.css
+++ b/styles.css
@@ -114,6 +114,35 @@ section h2 {
   color: #3498db; /* Blue for repo name */
   margin-top: 0;
   margin-bottom: 10px;
+  /* display: inline-block; Align heading with the icon */
+  /* vertical-align: middle; Align heading with the icon */
+  /* The above were moved to the updated rule below */
+}
+
+/* Styles for the header within a repo card (icon + title) */
+.repo-header {
+  display: flex; /* Arrange icon and title in a row */
+  align-items: center; /* Vertically align icon and title */
+  margin-bottom: 10px; /* Space below the header (icon + title) */
+}
+
+/* Icon Styles */
+.repo-icon {
+  font-size: 1.5em;
+  margin-right: 10px;
+  /* display: inline-block; /* Potentially redundant with flex parent */
+  /* vertical-align: middle; /* Potentially redundant with flex parent */
+}
+
+/* Adjustments for repo name to align with icon if needed */
+.repo-card h3 {
+  /* display: inline-block; /* Potentially redundant if flex parent handles alignment */
+  /* vertical-align: middle; /* Potentially redundant */
+  font-size: 1.4em;
+  color: #3498db;
+  margin-top: 0;
+  /* margin-bottom: 10px; /* Removed, repo-header will handle this spacing */
+  margin-left: 0; /* Ensure no extra left margin if icon provides right margin */
 }
 
 .repo-card p {


### PR DESCRIPTION
This commit introduces icons to the left of each repository name in the portfolio page.

Key changes:
- Added a `getRepoIcon` function in `script.js` to select an emoji icon based on keywords found in the repository's name and description.
- Modified `script.js` to create a `span.repo-icon` element for each repository and display the selected emoji.
- Wrapped the icon and repository title (`h3`) in a new `div.repo-header` for better layout control.
- Added CSS styles for `.repo-icon` to control its size and spacing.
- Added CSS styles for `.repo-header` to use flexbox for aligning the icon and title horizontally.
- Adjusted existing styles for `.repo-card h3` to work well with the new flexbox layout and ensure proper spacing.

The icons provide a quick visual cue related to the repository's content, enhancing your experience.